### PR TITLE
feat: LLM-powered 404 page with article recommendations

### DIFF
--- a/app/api/not-found/route.ts
+++ b/app/api/not-found/route.ts
@@ -1,0 +1,38 @@
+import { streamText } from "ai";
+import { google } from "@ai-sdk/google";
+import { getAllPosts } from "@/lib/posts";
+import { buildNotFoundSystemPrompt } from "@/lib/prompt";
+import type { Language, Style } from "@/lib/types";
+
+function getStyleInstruction(style?: Style): string {
+  switch (style) {
+    case "quick":
+      return `\nStyle instructions:
+- Keep the 404 message to one short sentence.
+- For recommendations, output only 3 bullet points with links. No extra prose.`;
+
+    case "detailed":
+      return `\nStyle instructions:
+- Make the 404 message warm and empathetic.
+- For each recommendation, explain in 2-3 sentences why the reader would find it valuable.`;
+
+    default:
+      return "";
+  }
+}
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const language = body.language as Language | undefined;
+  const style = body.style as Style | undefined;
+
+  const posts = getAllPosts();
+
+  const result = streamText({
+    model: google(process.env.AI_MODEL || "gemini-3-flash-preview"),
+    system: buildNotFoundSystemPrompt(posts, language),
+    prompt: `The user landed on a 404 page. Generate a friendly message and recommend 3 articles.${getStyleInstruction(style)}`,
+  });
+
+  return result.toTextStreamResponse();
+}

--- a/app/api/not-found/route.ts
+++ b/app/api/not-found/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
   const posts = getAllPosts();
 
   const result = streamText({
-    model: google(process.env.AI_MODEL || "gemini-3-flash-preview"),
+    model: google(process.env.AI_DIGEST_MODEL || "gemini-2.5-flash-lite"),
     system: buildNotFoundSystemPrompt(posts, language),
     prompt: `The user landed on a 404 page. Generate a friendly message and recommend 3 articles.${getStyleInstruction(style)}`,
   });

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,39 +1,14 @@
-import Link from "next/link";
-import { SearchIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { headers } from "next/headers";
+import { NotFoundClient } from "@/components/blog/NotFoundClient";
+import { getPreferredLanguageFromHeaders } from "@/lib/language";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const preferredLanguage = getPreferredLanguageFromHeaders(await headers());
+
   return (
     <div className="flex max-w-[1320px] mx-auto overflow-x-hidden">
       <main className="flex-1 min-w-0">
-        <div className="max-w-[880px] mx-auto px-6 sm:px-8 pt-16 pb-32">
-          <div className="relative overflow-hidden rounded-2xl border bg-card/70 shadow-sm">
-            <div className="absolute inset-0">
-              <div className="absolute -top-24 right-0 h-56 w-56 rounded-full bg-accent/40 blur-3xl" />
-              <div className="absolute -bottom-28 left-6 h-72 w-72 rounded-full bg-secondary/60 blur-3xl" />
-            </div>
-            <div className="relative p-8 sm:p-12">
-              <p className="text-[0.6875rem] uppercase tracking-[0.35em] text-muted-foreground">
-                404
-              </p>
-              <h1 className="mt-3 text-3xl sm:text-4xl font-semibold tracking-[-0.03em] text-foreground">
-                ページが見つかりません
-              </h1>
-              <p className="mt-3 text-[0.9375rem] leading-relaxed text-muted-foreground max-w-[34rem]">
-                URLが変更されたか、削除された可能性があります。トップに戻るか、検索で目的の投稿を探してください。
-              </p>
-              <div className="mt-6 flex flex-wrap gap-3">
-                <Button asChild>
-                  <Link href="/">トップへ戻る</Link>
-                </Button>
-                <Button variant="outline" data-search-trigger>
-                  <SearchIcon className="size-4" />
-                  検索を開く
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <NotFoundClient initialLanguage={preferredLanguage} />
       </main>
     </div>
   );

--- a/components/blog/NotFoundClient.tsx
+++ b/components/blog/NotFoundClient.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCompletion } from "@ai-sdk/react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
+import { SearchIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "./Markdown";
+import { StyleSelector } from "./StyleSelector";
+import type { Language, StyleOptions } from "@/lib/types";
+import { isSupportedLanguage } from "@/lib/language";
+
+interface NotFoundClientProps {
+  initialLanguage?: Language;
+}
+
+const LANGUAGE_STORAGE_KEY = "preferred-language";
+
+function getStoredLanguage() {
+  if (typeof window === "undefined") return null;
+  const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  if (!stored || !isSupportedLanguage(stored)) return null;
+  return stored;
+}
+
+function storeLanguage(language: Language) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+}
+
+export function NotFoundClient({ initialLanguage }: NotFoundClientProps) {
+  const [style, setStyle] = useState<StyleOptions>(() => ({
+    language: initialLanguage ?? "ja",
+    style: "quick",
+  }));
+
+  const { completion, isLoading, complete, error } = useCompletion({
+    api: "/api/not-found",
+    body: {
+      language: style.language,
+      style: style.style,
+    },
+    streamProtocol: "text",
+  });
+
+  const initialRef = useRef(false);
+  useEffect(() => {
+    if (!initialRef.current) {
+      initialRef.current = true;
+      const storedLanguage = getStoredLanguage();
+      if (storedLanguage && storedLanguage !== style.language) {
+        setStyle((prev) => ({ ...prev, language: storedLanguage }));
+        void complete("", {
+          body: {
+            language: storedLanguage,
+            style: style.style,
+          },
+        });
+        return;
+      }
+      complete("");
+    }
+  }, [complete, style.language, style.style]);
+
+  const handleStyleChange = useCallback(
+    (newStyle: StyleOptions) => {
+      setStyle(newStyle);
+      storeLanguage(newStyle.language);
+      void complete("", {
+        body: {
+          language: newStyle.language,
+          style: newStyle.style,
+        },
+      });
+    },
+    [complete],
+  );
+
+  return (
+    <div className="max-w-[880px] mx-auto px-6 sm:px-8 pt-16 pb-32">
+      <div className="relative overflow-hidden rounded-2xl border bg-card/70 shadow-sm">
+        <div className="absolute inset-0">
+          <div className="absolute -top-24 right-0 h-56 w-56 rounded-full bg-accent/40 blur-3xl" />
+          <div className="absolute -bottom-28 left-6 h-72 w-72 rounded-full bg-secondary/60 blur-3xl" />
+        </div>
+        <div className="relative p-8 sm:p-12">
+          <p className="text-[0.6875rem] uppercase tracking-[0.35em] text-muted-foreground">
+            404
+          </p>
+          <h1 className="mt-3 text-3xl sm:text-4xl font-semibold tracking-[-0.03em] text-foreground">
+            Page not found
+          </h1>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <Button asChild>
+              <Link href="/">トップへ戻る</Link>
+            </Button>
+            <Button variant="outline" data-search-trigger>
+              <SearchIcon className="size-4" />
+              検索を開く
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <StyleSelector
+          value={style}
+          onChange={handleStyleChange}
+          disabled={isLoading}
+          showOriginal={false}
+        />
+      </div>
+
+      <div className="mt-8 text-[0.9375rem] leading-[1.8] text-muted-foreground min-h-[200px]">
+        {isLoading && !completion && (
+          <div className="flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
+            <span className="w-[6px] h-[6px] rounded-full bg-emerald-400 animate-pulse-dot" />
+            <span>Generating...</span>
+          </div>
+        )}
+        {error ? (
+          <p className="text-destructive">
+            生成に失敗しました。
+            <Button
+              variant="link"
+              size="sm"
+              onClick={() => complete("")}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              再試行
+            </Button>
+          </p>
+        ) : completion ? (
+          <Markdown isAnimating={isLoading}>{completion}</Markdown>
+        ) : null}
+      </div>
+
+      {completion && !isLoading && (
+        <div className="mt-4 flex justify-end">
+          <Button variant="outline" size="xs" onClick={() => complete("")}>
+            Regenerate
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/blog/NotFoundClient.tsx
+++ b/components/blog/NotFoundClient.tsx
@@ -14,6 +14,56 @@ interface NotFoundClientProps {
   initialLanguage?: Language;
 }
 
+const i18n: Record<
+  Language,
+  {
+    pageNotFound: string;
+    backToTop: string;
+    openSearch: string;
+    generating: string;
+    generationFailed: string;
+    retry: string;
+    regenerate: string;
+  }
+> = {
+  ja: {
+    pageNotFound: "ページが見つかりません",
+    backToTop: "トップへ戻る",
+    openSearch: "検索を開く",
+    generating: "生成中...",
+    generationFailed: "生成に失敗しました。",
+    retry: "再試行",
+    regenerate: "Regenerate",
+  },
+  en: {
+    pageNotFound: "Page not found",
+    backToTop: "Back to top",
+    openSearch: "Search",
+    generating: "Generating...",
+    generationFailed: "Generation failed.",
+    retry: "Retry",
+    regenerate: "Regenerate",
+  },
+  zh: {
+    pageNotFound: "页面未找到",
+    backToTop: "返回首页",
+    openSearch: "搜索",
+    generating: "生成中...",
+    generationFailed: "生成失败。",
+    retry: "重试",
+    regenerate: "Regenerate",
+  },
+  ko: {
+    pageNotFound: "페이지를 찾을 수 없습니다",
+    backToTop: "홈으로 돌아가기",
+    openSearch: "검색",
+    generating: "생성 중...",
+    generationFailed: "생성에 실패했습니다.",
+    retry: "재시도",
+    regenerate: "Regenerate",
+  },
+};
+
 const LANGUAGE_STORAGE_KEY = "preferred-language";
 
 function getStoredLanguage() {
@@ -76,6 +126,8 @@ export function NotFoundClient({ initialLanguage }: NotFoundClientProps) {
     [complete],
   );
 
+  const t = i18n[style.language];
+
   return (
     <div className="max-w-[880px] mx-auto px-6 sm:px-8 pt-16 pb-32">
       <div className="relative overflow-hidden rounded-2xl border bg-card/70 shadow-sm">
@@ -88,15 +140,15 @@ export function NotFoundClient({ initialLanguage }: NotFoundClientProps) {
             404
           </p>
           <h1 className="mt-3 text-3xl sm:text-4xl font-semibold tracking-[-0.03em] text-foreground">
-            Page not found
+            {t.pageNotFound}
           </h1>
           <div className="mt-6 flex flex-wrap gap-3">
             <Button asChild>
-              <Link href="/">トップへ戻る</Link>
+              <Link href="/">{t.backToTop}</Link>
             </Button>
             <Button variant="outline" data-search-trigger>
               <SearchIcon className="size-4" />
-              検索を開く
+              {t.openSearch}
             </Button>
           </div>
         </div>
@@ -115,19 +167,19 @@ export function NotFoundClient({ initialLanguage }: NotFoundClientProps) {
         {isLoading && !completion && (
           <div className="flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
             <span className="w-[6px] h-[6px] rounded-full bg-emerald-400 animate-pulse-dot" />
-            <span>Generating...</span>
+            <span>{t.generating}</span>
           </div>
         )}
         {error ? (
           <p className="text-destructive">
-            生成に失敗しました。
+            {t.generationFailed}
             <Button
               variant="link"
               size="sm"
               onClick={() => complete("")}
               className="text-muted-foreground hover:text-foreground"
             >
-              再試行
+              {t.retry}
             </Button>
           </p>
         ) : completion ? (
@@ -138,7 +190,7 @@ export function NotFoundClient({ initialLanguage }: NotFoundClientProps) {
       {completion && !isLoading && (
         <div className="mt-4 flex justify-end">
           <Button variant="outline" size="xs" onClick={() => complete("")}>
-            Regenerate
+            {t.regenerate}
           </Button>
         </div>
       )}

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -77,6 +77,34 @@ Style:
 - Output in Markdown format`;
 }
 
+export function buildNotFoundSystemPrompt(
+  posts: readonly Post[],
+  language?: Language,
+): string {
+  const lang = getOutputLanguageName(language);
+
+  const postsList = posts
+    .map((p) => `- [${p.title}](/${p.path}) — ${p.description || p.summary}`)
+    .join("\n");
+
+  return `You are a helpful blog assistant. The user reached a 404 page (page not found).
+
+CRITICAL — Output language: You MUST write the entire output in ${lang}. Every sentence must be in ${lang}.
+
+Your task:
+1. Write a short, friendly 404 message (1-2 sentences). Be creative and slightly playful, but not silly.
+2. Then recommend 3 articles from the list below that the user might enjoy. Pick diverse topics.
+
+Output format (highest priority):
+- Output only Markdown. No preamble, no closing remarks.
+- The very first character must be the start of the 404 message.
+- After the 404 message, add a blank line, then a heading "## Recommended" (localized to ${lang}), then list 3 articles as bullet points with Markdown links: [Title](/path).
+- For each recommended article, add a one-sentence reason why it's interesting.
+
+Available articles:
+${postsList}`;
+}
+
 export function buildSearchSystemPrompt(posts: readonly Post[]): string {
   const postsData = posts
     .map(


### PR DESCRIPTION
## Summary

- Replace the static 404 page with an AI-generated experience powered by the same LLM pipeline used for blog posts and digests
- The 404 page now generates a creative not-found message and recommends 3 blog articles, all via streaming text generation
- Supports language switching (ja/en/zh/ko) via `Accept-Language` header detection and `localStorage` persistence, plus writing style controls (quick/detailed)

## Changes

| File | Description |
|------|-------------|
| `lib/prompt.ts` | Add `buildNotFoundSystemPrompt` — feeds the full article catalog to the LLM with instructions to produce a 404 message + 3 recommendations |
| `app/api/not-found/route.ts` | New streaming API endpoint (`POST /api/not-found`) accepting `language` and `style` params |
| `components/blog/NotFoundClient.tsx` | Client component using `useCompletion` with `StyleSelector`, streaming Markdown display, and Regenerate button |
| `app/not-found.tsx` | Server Component that detects preferred language from `Accept-Language` header and renders `NotFoundClient` |
| `lib/posts.ts` | Remove now-unused `getRandomPostMeta` (replaced by LLM selection) |

## Notes

- Every 404 page visit triggers an LLM API call. If bot traffic is a concern, consider adding rate limiting to `/api/not-found`.
- The `StyleSelector` hides the "Original" option since there is no raw source content for the 404 page.