### PR TITLE
docs: Update README.md to reflect current Next.js 16 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,86 @@
-# Website
+# Personal Blog
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+AI-powered content generation blog. Built with Next.js 16 (App Router) on Cloudflare Workers via OpenNext.
 
-### Installation
+## Features
+
+- AI-powered article transformation (configurable language, tone, detail level)
+- Streaming markdown rendering with Streamdown
+- Dark UI (Design 7 - OpenAI-inspired)
+- Content negotiation for raw markdown access
+
+## Prerequisites
+
+- Node.js ^24.13.1 (managed by Volta)
+- pnpm
+- OpenAI API key
+
+## Installation
+
+```bash
+pnpm install
+```
+
+## Environment Setup
+
+Create `.dev.vars` for local development:
 
 ```
-$ pnpm install
+OPENAI_API_KEY=your_key_here
 ```
 
-### Local Development
+## Development
 
-```
-$ pnpm start
-```
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-```
-$ pnpm build
+```bash
+pnpm dev              # Start dev server (Turbopack)
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+## Build & Deploy
+
+```bash
+pnpm build            # Production build
+pnpm preview          # Build + preview on Workers locally
+pnpm deploy           # Build + deploy to Cloudflare
+```
+
+## Content Management
+
+Blog posts are stored in `/content/blog/*.mdx` with frontmatter:
+
+```yaml
+title: Post Title
+date: YYYY-MM-DD
+description: Brief description
+categories: [category]
+tags: [tag1, tag2]
+```
+
+After adding/editing posts:
+
+```bash
+pnpm build:content-index  # Rebuild content index
+```
+
+## Key Routes
+
+- `/` — Blog listing with AI-generated digest
+- `/[slug]` — Post page with style controls
+- `/YYYY/MM/DD/slug` — Old Docusaurus-style URLs (redirect support)
+- `/topics/[topic]` — Topic-filtered listing
+- `/tags` — All tags listing
+- `/tags/[tag]` — Tag-filtered posts
+- `/api/search` — Agentic search endpoint
+- `/api/feed.xml` — Atom feed
+- `/api/rss.xml` — RSS feed
+
+### Smart 404 Page
+
+404 errors trigger LLM-powered recommendations based on similar posts.
+
+## Code Formatting
+
+```bash
+pnpm format           # Format with Prettier
+```
+
+Pre-commit hooks (Lefthook) run automatically on commit.


### PR DESCRIPTION
## Summary

Completely rewrite README.md to accurately document the current project architecture.

## Changes

- **Framework**: Updated from Docusaurus 2 to Next.js 16 (App Router) + Cloudflare Workers via OpenNext
- **Features**: Added comprehensive list of AI-powered features and UI design system
- **Prerequisites**: Documented Node.js, Volta, pnpm, and OpenAI API key requirements
- **Scripts**: Documented all available pnpm commands (dev, build, preview, deploy, etc.)
- **Content**: Added content management section with MDX frontmatter examples
- **Routes**: Complete list of all routes including:
  - Blog listing and post pages
  - Legacy Docusaurus URL redirect support
  - Topic and tag filtering
  - API endpoints (search, feeds)
- **Smart 404**: Added documentation for LLM-powered 404 recommendations
- **Tooling**: Updated pre-commit hooks from Husky to Lefthook

## Why

The previous README was significantly outdated (still referencing Docusaurus 2), which could confuse new contributors or users trying to set up the project locally.