### PR TITLE
feat: generative UI for root page digest

### DIFF
--- a/app/api/digest/route.ts
+++ b/app/api/digest/route.ts
@@ -9,16 +9,18 @@ function getStyleInstruction(style?: Style): string {
   switch (style) {
     case "quick":
       return `\nStyle instructions:
-- Keep text portions very concise (1-2 sentences each)
-- Favor using tools over writing long prose
-- Use showPostCards with 2-3 posts max`;
+- Keep text minimal: only a 1-sentence intro.
+- Rely primarily on tools: use showPostCards with all relevant posts grouped logically, and showTagCloud at the end.
+- Use showTopicHighlight for each major theme (2-3 topics), with brief summaries.
+- The visual UI components ARE the digest in quick mode.`;
 
     case "detailed":
     default:
       return `\nStyle instructions:
-- Write detailed connecting text between tool uses
-- Explain each topic's significance and context
-- Use showTopicHighlight for deeper analysis of each area`;
+- Write substantial prose covering every article: explain key points, background, and practical value.
+- Use Markdown links ([Title](/path)) when mentioning articles in text.
+- The TEXT is the primary digest. After the text, optionally add showPostCards for 2-3 featured posts and showTagCloud for navigation.
+- Do NOT rely on tools to convey information — your text should be a complete, standalone digest.`;
   }
 }
 

--- a/app/api/digest/route.ts
+++ b/app/api/digest/route.ts
@@ -1,24 +1,24 @@
-import { streamText } from "ai";
+import { streamText, tool, convertToModelMessages, stepCountIs } from "ai";
 import { google } from "@ai-sdk/google";
+import { z } from "zod";
 import { getAllPosts } from "@/lib/posts";
 import { buildDigestSystemPrompt } from "@/lib/prompt";
-import type { Language, Style } from "@/lib/types";
+import type { Language, Style, PostMeta } from "@/lib/types";
 
 function getStyleInstruction(style?: Style): string {
   switch (style) {
     case "quick":
       return `\nStyle instructions:
-- Output only 3-5 bullet points summarizing the key takeaways. Nothing else.
-- Do NOT add prose, explanations, or supplements after the bullets. End with the bullets.
-- Each bullet must be one sentence. Include links to the articles.
-- No headings (#). Use only bullet points (-).`;
+- Keep text portions very concise (1-2 sentences each)
+- Favor using tools over writing long prose
+- Use showPostCards with 2-3 posts max`;
 
     case "detailed":
     default:
       return `\nStyle instructions:
-- Use polite, approachable language
-- Explain each article's key points and background in detail
-- Convey the value and practical use cases for the reader`;
+- Write detailed connecting text between tool uses
+- Explain each topic's significance and context
+- Use showTopicHighlight for deeper analysis of each area`;
   }
 }
 
@@ -28,6 +28,7 @@ export async function POST(req: Request) {
   const tag = body.tag as string | undefined;
   const language = body.language as Language | undefined;
   const style = body.style as Style | undefined;
+  const uiMessages = body.messages ?? [];
 
   let posts = getAllPosts();
   if (topic) {
@@ -36,14 +37,85 @@ export async function POST(req: Request) {
   if (tag) {
     posts = posts.filter((p) => p.tags.includes(tag));
   }
-  // Use the most recent posts for digest
   const recentPosts = posts.slice(0, 10);
+
+  const allPosts = getAllPosts();
+  const postMap = new Map(allPosts.map((p) => [p.slug, p as PostMeta]));
+
+  const modelMessages = await convertToModelMessages(uiMessages);
+
+  const promptText = `${topic ? `Generate a digest about recent "${topic}" posts.` : tag ? `Generate a digest about posts tagged "${tag}".` : "Generate a digest about recent posts."}${getStyleInstruction(style)}`;
 
   const result = streamText({
     model: google(process.env.AI_DIGEST_MODEL || "gemini-2.5-flash-lite"),
     system: buildDigestSystemPrompt(recentPosts, language),
-    prompt: `${topic ? `Generate a digest about recent "${topic}" posts.` : tag ? `Generate a digest about posts tagged "${tag}".` : "Generate a digest about recent posts."}${getStyleInstruction(style)}`,
+    messages:
+      modelMessages.length > 0
+        ? modelMessages
+        : [{ role: "user" as const, content: promptText }],
+    tools: {
+      showPostCards: tool({
+        description:
+          "Display a grid of article cards. Use to highlight specific recommended posts.",
+        inputSchema: z.object({
+          slugs: z.array(z.string()).describe("Post slugs to display"),
+          heading: z
+            .string()
+            .optional()
+            .describe("Optional heading above the cards"),
+        }),
+        execute: async ({ slugs, heading }) => {
+          const found = slugs
+            .map((s) => postMap.get(s))
+            .filter((p): p is PostMeta => p != null);
+          return { posts: found, heading };
+        },
+      }),
+      showTopicHighlight: tool({
+        description:
+          "Show a topic highlight section with a summary and related posts. Use for thematic grouping.",
+        inputSchema: z.object({
+          topic: z.string().describe("Topic name"),
+          summary: z
+            .string()
+            .describe("Brief summary of the topic trend or theme"),
+          slugs: z.array(z.string()).describe("Related post slugs"),
+        }),
+        execute: async ({ topic: t, summary, slugs }) => {
+          const found = slugs
+            .map((s) => postMap.get(s))
+            .filter((p): p is PostMeta => p != null);
+          return { topic: t, summary, posts: found };
+        },
+      }),
+      showTagCloud: tool({
+        description:
+          "Display a tag cloud showing popular tags for navigation. Use at the end.",
+        inputSchema: z.object({
+          tags: z
+            .array(z.string())
+            .describe("Tag names to display in the cloud"),
+        }),
+        execute: async ({ tags: tagNames }) => {
+          const tagCounts = new Map<string, number>();
+          for (const p of allPosts) {
+            for (const t of p.tags) {
+              if (tagNames.includes(t)) {
+                tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+              }
+            }
+          }
+          return {
+            tags: tagNames.map((name) => ({
+              name,
+              count: tagCounts.get(name) ?? 0,
+            })),
+          };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
   });
 
-  return result.toTextStreamResponse();
+  return result.toUIMessageStreamResponse();
 }

--- a/app/api/digest/route.ts
+++ b/app/api/digest/route.ts
@@ -8,19 +8,21 @@ import type { Language, Style, PostMeta } from "@/lib/types";
 function getStyleInstruction(style?: Style): string {
   switch (style) {
     case "quick":
-      return `\nStyle instructions:
-- Keep text minimal: only a 1-sentence intro.
-- Rely primarily on tools: use showPostCards with all relevant posts grouped logically, and showTagCloud at the end.
-- Use showTopicHighlight for each major theme (2-3 topics), with brief summaries.
-- The visual UI components ARE the digest in quick mode.`;
+      return `\nStyle instructions (QUICK mode — tool-centric, minimal text):
+- Text: only 1-2 sentence intro. No detailed prose.
+- Use showTopicHighlight for 2-3 major themes (brief summary each).
+- Use showPostCards to surface key posts.
+- End with showTagCloud for navigation.
+- The UI components ARE the digest. Text is just glue between them.`;
 
     case "detailed":
     default:
-      return `\nStyle instructions:
+      return `\nStyle instructions (DETAILED mode — text-centric, rich prose):
 - Write substantial prose covering every article: explain key points, background, and practical value.
-- Use Markdown links ([Title](/path)) when mentioning articles in text.
-- The TEXT is the primary digest. After the text, optionally add showPostCards for 2-3 featured posts and showTagCloud for navigation.
-- Do NOT rely on tools to convey information — your text should be a complete, standalone digest.`;
+- When mentioning a post in text, always use Markdown link format: [Post Title](/YYYY/MM/DD/slug).
+- The text IS the digest. It should be a complete, standalone read.
+- After the text, add showPostCards for 2-3 featured posts and showTagCloud for navigation.
+- Do NOT use showTopicHighlight — the detailed text already covers topics.`;
   }
 }
 

--- a/components/blog/DigestParts.tsx
+++ b/components/blog/DigestParts.tsx
@@ -16,6 +16,12 @@ interface DigestPartsProps {
 }
 
 export function DigestParts({ parts, isAnimating }: DigestPartsProps) {
+  if (process.env.NODE_ENV === "development") {
+    console.log(
+      "[DigestParts] parts:",
+      parts.map((p) => ({ type: p.type, state: "state" in p ? p.state : undefined })),
+    );
+  }
   return (
     <div className="space-y-4">
       {parts.map((part, i) => {

--- a/components/blog/DigestParts.tsx
+++ b/components/blog/DigestParts.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import type { UIMessage } from "ai";
+import { Markdown } from "./Markdown";
+import { PostCard } from "./PostCard";
+import { Badge } from "@/components/ui/badge";
+import type { DigestTools, PostMeta } from "@/lib/types";
+
+type DigestMessage = UIMessage<unknown, never, DigestTools>;
+type DigestPart = DigestMessage["parts"][number];
+
+interface DigestPartsProps {
+  parts: DigestPart[];
+  isAnimating: boolean;
+}
+
+export function DigestParts({ parts, isAnimating }: DigestPartsProps) {
+  return (
+    <div className="space-y-4">
+      {parts.map((part, i) => {
+        switch (part.type) {
+          case "text":
+            return part.text ? (
+              <Markdown key={i} isAnimating={isAnimating}>
+                {part.text}
+              </Markdown>
+            ) : null;
+
+          case "tool-showPostCards":
+            if (part.state === "output-available") {
+              return (
+                <PostCardsSection key={part.toolCallId} data={part.output} />
+              );
+            }
+            return <ToolSkeleton key={part.toolCallId} />;
+
+          case "tool-showTopicHighlight":
+            if (part.state === "output-available") {
+              return (
+                <TopicHighlightSection
+                  key={part.toolCallId}
+                  data={part.output}
+                />
+              );
+            }
+            return <ToolSkeleton key={part.toolCallId} />;
+
+          case "tool-showTagCloud":
+            if (part.state === "output-available") {
+              return (
+                <TagCloudSection key={part.toolCallId} data={part.output} />
+              );
+            }
+            return <ToolSkeleton key={part.toolCallId} />;
+
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}
+
+function PostCardsSection({
+  data,
+}: {
+  data: { posts: PostMeta[]; heading?: string };
+}) {
+  if (data.posts.length === 0) return null;
+  return (
+    <div>
+      {data.heading && (
+        <h3 className="text-[0.6875rem] font-medium text-muted-foreground uppercase tracking-[0.1em] mb-3">
+          {data.heading}
+        </h3>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {data.posts.map((post) => (
+          <PostCard key={post.slug} post={post} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TopicHighlightSection({
+  data,
+}: {
+  data: { topic: string; summary: string; posts: PostMeta[] };
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-accent/30 p-4">
+      <h3 className="text-sm font-semibold text-foreground mb-1.5">
+        {data.topic}
+      </h3>
+      <p className="text-[0.8125rem] text-muted-foreground leading-relaxed mb-3">
+        {data.summary}
+      </p>
+      {data.posts.length > 0 && (
+        <ul className="space-y-1">
+          {data.posts.map((post) => (
+            <li key={post.slug}>
+              <Link
+                href={`/${post.path}`}
+                className="text-[0.8125rem] text-foreground hover:text-primary transition-colors"
+              >
+                {post.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TagCloudSection({
+  data,
+}: {
+  data: { tags: { name: string; count: number }[] };
+}) {
+  if (data.tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {data.tags.map((tag) => (
+        <Link key={tag.name} href={`/tags/${tag.name}`}>
+          <Badge
+            variant="secondary"
+            className="text-[0.75rem] cursor-pointer hover:bg-accent transition-colors"
+          >
+            {tag.name}
+            {tag.count > 0 && (
+              <span className="ml-1 text-muted-foreground">({tag.count})</span>
+            )}
+          </Badge>
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function ToolSkeleton() {
+  return (
+    <div className="animate-pulse rounded-lg bg-accent/40 h-20 flex items-center justify-center">
+      <div className="w-4 h-4 rounded-full bg-muted-foreground/20 animate-bounce" />
+    </div>
+  );
+}

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -15,29 +15,37 @@ export function PostCard({ post }: PostCardProps) {
   });
 
   return (
-    <Link href={`/${post.path}`} className="group block no-underline">
-      <Card className="p-5 py-5 gap-0 hover:bg-accent transition-all">
-        <CardContent className="p-0">
-          <time className="text-xs text-muted-foreground block mb-3">{monthYear}</time>
-          <ViewTransition name={`post-title-${post.slug}`}>
-            <h3 className="text-[0.9375rem] font-semibold text-foreground leading-snug mb-2">
+    <Card className="p-5 py-5 gap-0 hover:bg-accent transition-all relative group">
+      <CardContent className="p-0">
+        <time className="text-xs text-muted-foreground block mb-3">{monthYear}</time>
+        <ViewTransition name={`post-title-${post.slug}`}>
+          <h3 className="text-[0.9375rem] font-semibold text-foreground leading-snug mb-2">
+            <Link
+              href={`/${post.path}`}
+              className="no-underline after:absolute after:inset-0"
+            >
               {post.title}
-            </h3>
-          </ViewTransition>
-          <p className="text-[0.8125rem] text-muted-foreground leading-relaxed line-clamp-2">
-            {post.description}
-          </p>
-          {post.tags.length > 0 && (
-            <div className="flex gap-1.5 mt-3 flex-wrap">
-              {post.tags.slice(0, 3).map((tag) => (
-                <Badge key={tag} variant="secondary" className="text-[0.6875rem]">
+            </Link>
+          </h3>
+        </ViewTransition>
+        <p className="text-[0.8125rem] text-muted-foreground leading-relaxed line-clamp-2">
+          {post.description}
+        </p>
+        {post.tags.length > 0 && (
+          <div className="flex gap-1.5 mt-3 flex-wrap relative z-10">
+            {post.tags.slice(0, 3).map((tag) => (
+              <Link key={tag} href={`/tags/${tag}`}>
+                <Badge
+                  variant="secondary"
+                  className="text-[0.6875rem] cursor-pointer hover:bg-accent-foreground/10"
+                >
                   {tag}
                 </Badge>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </Link>
+              </Link>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -20,28 +20,34 @@ export function buildDigestSystemPrompt(
   const postsSummary = posts
     .map(
       (p) =>
-        `- [${p.title}](/${p.path}) (${p.date}) — ${p.description || p.summary}`,
+        `- slug: "${p.slug}" | [${p.title}](/${p.path}) (${p.date}) — ${p.description || p.summary} [tags: ${p.tags.join(", ")}]`,
     )
     .join("\n");
 
   const lang = getOutputLanguageName(language);
 
-  return `You are a blog digest generator.
-Analyze the following blog posts and generate a short digest summarizing recent trends and highlights.
+  return `You are a blog digest generator with UI component tools.
+Analyze the following blog posts and generate a digest using a mix of text and UI components.
 
-CRITICAL — Output language: You MUST write the entire output in ${lang}. Every sentence must be in ${lang}.
+CRITICAL — Output language: You MUST write all text output in ${lang}. Every sentence must be in ${lang}.
 
-Output format (highest priority):
-- Output only the digest body in Markdown
-- Do NOT output any preamble ("Sure, here's", "Here's a digest", "承知しました", "以下に" etc.) in any language
-- Do NOT output any closing remarks ("Stay tuned!", "いかがでしたか" etc.)
-- The very first character of your output must be the first character of the digest body
+You have three UI tools available:
+- showPostCards: Display article cards in a grid. Pass post slugs and an optional heading.
+- showTopicHighlight: Highlight a topic/theme with a summary and related posts. Pass topic name, summary text, and related post slugs.
+- showTagCloud: Display popular tags for navigation. Pass tag names.
+
+How to compose the digest:
+1. Start with a brief text introduction (1-2 sentences about recent activity)
+2. Use showTopicHighlight for 1-2 major topic areas you identify in the posts
+3. Use showPostCards to recommend 2-4 posts the reader should check out
+4. Optionally end with showTagCloud showing relevant tags
+5. Add brief connecting text between tool uses to create a natural flow
 
 Rules:
-- Only reference the provided post data
-- When mentioning a post, always use Markdown link format: [Post Title](/YYYY/MM/DD/slug). Use links, not bold text
-- Mention specific topics and keywords
-- Write naturally and readably
+- Pass post SLUGS (the "slug" field) to tool parameters, not paths or URLs
+- Only use slugs and tags from the provided post data below
+- Do NOT output preamble ("Sure, here's", "承知しました" etc.) or closing remarks
+- The very first character of your output must be the start of the digest
 
 Posts:
 ${postsSummary}`;

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -37,11 +37,11 @@ You have three UI tools available:
 - showTagCloud: Display popular tags for navigation. Pass tag names.
 
 How to compose the digest:
-- The TEXT is the primary content. Write detailed, substantive descriptions for each article — explain key points, background, and practical value just as you would in a traditional digest.
-- When mentioning a post in text, always use Markdown link format: [Post Title](/YYYY/MM/DD/slug).
-- Use tools to SUPPLEMENT the text, not replace it. Tools add visual richness alongside your detailed writing.
-- After your main text digest (covering all major posts), optionally use showPostCards to visually highlight 2-3 key posts, or showTagCloud for navigation.
-- Do NOT write thin text and rely on tools for the substance. The text alone should be a complete, informative digest.
+1. Start with a brief text introduction (1-2 sentences about recent activity)
+2. Use showTopicHighlight for 1-2 major topic areas you identify in the posts
+3. Use showPostCards to recommend 2-4 posts the reader should check out
+4. Optionally end with showTagCloud showing relevant tags
+5. Add brief connecting text between tool uses to create a natural flow
 
 Rules:
 - Pass post SLUGS (the "slug" field) to tool parameters, not paths or URLs

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -36,12 +36,7 @@ You have three UI tools available:
 - showTopicHighlight: Highlight a topic/theme with a summary and related posts. Pass topic name, summary text, and related post slugs.
 - showTagCloud: Display popular tags for navigation. Pass tag names.
 
-How to compose the digest:
-1. Start with a brief text introduction (1-2 sentences about recent activity)
-2. Use showTopicHighlight for 1-2 major topic areas you identify in the posts
-3. Use showPostCards to recommend 2-4 posts the reader should check out
-4. Optionally end with showTagCloud showing relevant tags
-5. Add brief connecting text between tool uses to create a natural flow
+Follow the "Style instructions" in the user message to decide how to compose the digest (how much text vs tools to use).
 
 Rules:
 - Pass post SLUGS (the "slug" field) to tool parameters, not paths or URLs

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -37,11 +37,11 @@ You have three UI tools available:
 - showTagCloud: Display popular tags for navigation. Pass tag names.
 
 How to compose the digest:
-1. Start with a brief text introduction (1-2 sentences about recent activity)
-2. Use showTopicHighlight for 1-2 major topic areas you identify in the posts
-3. Use showPostCards to recommend 2-4 posts the reader should check out
-4. Optionally end with showTagCloud showing relevant tags
-5. Add brief connecting text between tool uses to create a natural flow
+- The TEXT is the primary content. Write detailed, substantive descriptions for each article — explain key points, background, and practical value just as you would in a traditional digest.
+- When mentioning a post in text, always use Markdown link format: [Post Title](/YYYY/MM/DD/slug).
+- Use tools to SUPPLEMENT the text, not replace it. Tools add visual richness alongside your detailed writing.
+- After your main text digest (covering all major posts), optionally use showPostCards to visually highlight 2-3 key posts, or showTagCloud for navigation.
+- Do NOT write thin text and rely on tools for the substance. The text alone should be a complete, informative digest.
 
 Rules:
 - Pass post SLUGS (the "slug" field) to tool parameters, not paths or URLs

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,3 +20,18 @@ export interface StyleOptions {
   language: Language;
   style: Style;
 }
+
+export type DigestTools = {
+  showPostCards: {
+    input: { slugs: string[]; heading?: string };
+    output: { posts: PostMeta[]; heading?: string };
+  };
+  showTopicHighlight: {
+    input: { topic: string; summary: string; slugs: string[] };
+    output: { topic: string; summary: string; posts: PostMeta[] };
+  };
+  showTagCloud: {
+    input: { tags: string[] };
+    output: { tags: { name: string; count: number }[] };
+  };
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-dom": "^19.2.4",
     "shiki": "^3.22.0",
     "streamdown": "^2.2.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@opennextjs/cloudflare": "1.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@opennextjs/cloudflare':
         specifier: 1.16.5
@@ -155,28 +158,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.40.5':
     resolution: {integrity: sha512-/qKsmds5FMoaEj6FdNzepbmLMtlFuBLdrAn9GIWCqOIcVcYvM1Nka8+mncfeXB/MFZKOrzQsQdPTWqrrQzXLrA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.40.5':
     resolution: {integrity: sha512-DP4oDbq7f/1A2hRTFLhJfDFR6aI5mRWdEfKfHzRItmlKsR9WlcEl1qDJs/zX9R2EEtIDsSKRzuJNfJllY3/W8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.40.5':
     resolution: {integrity: sha512-BRZUvVBPUNpWPo6Ns8chXVzxHPY+k9gpsubGTHy92Q26ecZULd/dTkWWdnvfhRqttsSQ9Pe/XQdi5+hDQ6RYcg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.40.5':
     resolution: {integrity: sha512-y95zSEwc7vhxmcrcH0GnK4ZHEBQrmrszRBNQovzaciF9GUqEcCACNLoBesn4V47IaOp4fYgD2/EhGRTIBFb2Ug==}
@@ -949,105 +948,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1175,28 +1158,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -2276,28 +2255,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3373,28 +3348,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}


### PR DESCRIPTION
## Summary

- Migrate the root page digest from plain text streaming (`useCompletion`) to **generative UI** (`useChat` + tools), enabling the AI to return a mix of text and structured UI components
- Define three server-side tools (`showPostCards`, `showTopicHighlight`, `showTagCloud`) that resolve post slugs to full metadata and render as interactive React components
- Add `DigestParts` component that dispatches on message part types to render `PostCard` grids, topic highlight sections, tag clouds, or Markdown text
- Update system prompt to instruct the model on tool usage patterns and provide post slugs for reference

### Key changes

| File | Change |
|------|--------|
| `app/api/digest/route.ts` | Add 3 tools with zod schemas, switch to `toUIMessageStreamResponse()`, use `convertToModelMessages` + `stepCountIs(3)` |
| `components/blog/ListingHero.tsx` | `useCompletion` → `useChat` with `DefaultChatTransport`, render `DigestParts` |
| `components/blog/DigestParts.tsx` | **New** — parts renderer mapping tool outputs to `PostCard`, `Badge`, `Markdown` |
| `lib/types.ts` | Add `DigestTools` type for typed tool parts |
| `lib/prompt.ts` | Add slug data and tool usage guidelines to digest prompt |
| `package.json` | Add `zod` dependency |

## Test plan

- [ ] Run `pnpm dev` and verify the digest loads on the root page
- [ ] Confirm AI returns a mix of text and UI components (PostCards, TopicHighlight, TagCloud)
- [ ] Verify skeleton/loading states appear while tools execute
- [ ] Test StyleSelector (language + style) triggers re-generation with correct params
- [ ] Test Regenerate button works
- [ ] Verify `pnpm build` succeeds without errors