### PR TITLE
feat: generative UI for 404 page

### DIFF
--- a/app/api/not-found/route.ts
+++ b/app/api/not-found/route.ts
@@ -1,23 +1,26 @@
-import { streamText } from "ai";
+import { streamText, tool, convertToModelMessages, stepCountIs } from "ai";
 import { google } from "@ai-sdk/google";
+import { z } from "zod";
 import { getAllPosts } from "@/lib/posts";
 import { buildNotFoundSystemPrompt } from "@/lib/prompt";
-import type { Language, Style } from "@/lib/types";
+import type { Language, Style, PostMeta } from "@/lib/types";
 
 function getStyleInstruction(style?: Style): string {
   switch (style) {
     case "quick":
-      return `\nStyle instructions:
-- Keep the 404 message to one short sentence.
-- For recommendations, output only 3 bullet points with links. No extra prose.`;
+      return `\nStyle instructions (QUICK mode — tool-centric):
+- Write a short, playful 404 message (1 sentence).
+- Use showPostCards to display 3 recommended articles. Pick diverse topics.
+- End with showTagCloud for navigation.
+- Keep text minimal — the UI components are the main content.`;
 
     case "detailed":
-      return `\nStyle instructions:
-- Make the 404 message warm and empathetic.
-- For each recommendation, explain in 2-3 sentences why the reader would find it valuable.`;
-
     default:
-      return "";
+      return `\nStyle instructions (DETAILED mode — text-centric):
+- Write a warm, friendly 404 message (1-2 sentences). Be creative but not silly.
+- Write a "Recommended" section with 3 articles as Markdown links: [Title](/path). For each, add 1-2 sentences explaining why the reader would find it valuable.
+- After the text, use showPostCards to also display the 3 recommended articles as cards.
+- The text should be a complete, standalone read.`;
   }
 }
 
@@ -25,14 +28,68 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => ({}));
   const language = body.language as Language | undefined;
   const style = body.style as Style | undefined;
+  const uiMessages = body.messages ?? [];
 
   const posts = getAllPosts();
+  const postMap = new Map(posts.map((p) => [p.slug, p as PostMeta]));
+
+  const modelMessages = await convertToModelMessages(uiMessages);
+
+  const promptText = `The user landed on a 404 page. Generate a friendly message and recommend articles.${getStyleInstruction(style)}`;
 
   const result = streamText({
     model: google(process.env.AI_DIGEST_MODEL || "gemini-2.5-flash-lite"),
     system: buildNotFoundSystemPrompt(posts, language),
-    prompt: `The user landed on a 404 page. Generate a friendly message and recommend 3 articles.${getStyleInstruction(style)}`,
+    messages:
+      modelMessages.length > 0
+        ? modelMessages
+        : [{ role: "user" as const, content: promptText }],
+    tools: {
+      showPostCards: tool({
+        description:
+          "Display a grid of article cards. Use to show recommended articles.",
+        inputSchema: z.object({
+          slugs: z.array(z.string()).describe("Post slugs to display"),
+          heading: z
+            .string()
+            .optional()
+            .describe("Optional heading above the cards"),
+        }),
+        execute: async ({ slugs, heading }) => {
+          const found = slugs
+            .map((s) => postMap.get(s))
+            .filter((p): p is PostMeta => p != null);
+          return { posts: found, heading };
+        },
+      }),
+      showTagCloud: tool({
+        description:
+          "Display a tag cloud showing popular tags for navigation.",
+        inputSchema: z.object({
+          tags: z
+            .array(z.string())
+            .describe("Tag names to display in the cloud"),
+        }),
+        execute: async ({ tags: tagNames }) => {
+          const tagCounts = new Map<string, number>();
+          for (const p of posts) {
+            for (const t of p.tags) {
+              if (tagNames.includes(t)) {
+                tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+              }
+            }
+          }
+          return {
+            tags: tagNames.map((name) => ({
+              name,
+              count: tagCounts.get(name) ?? 0,
+            })),
+          };
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
   });
 
-  return result.toTextStreamResponse();
+  return result.toUIMessageStreamResponse();
 }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -85,22 +85,27 @@ export function buildNotFoundSystemPrompt(
   const lang = getOutputLanguageName(language);
 
   const postsList = posts
-    .map((p) => `- [${p.title}](/${p.path}) — ${p.description || p.summary}`)
+    .map(
+      (p) =>
+        `- slug: "${p.slug}" | [${p.title}](/${p.path}) — ${p.description || p.summary} [tags: ${p.tags.join(", ")}]`,
+    )
     .join("\n");
 
-  return `You are a helpful blog assistant. The user reached a 404 page (page not found).
+  return `You are a helpful blog assistant with UI component tools. The user reached a 404 page (page not found).
 
 CRITICAL — Output language: You MUST write the entire output in ${lang}. Every sentence must be in ${lang}.
 
-Your task:
-1. Write a short, friendly 404 message (1-2 sentences). Be creative and slightly playful, but not silly.
-2. Then recommend 3 articles from the list below that the user might enjoy. Pick diverse topics.
+You have UI tools available:
+- showPostCards: Display article cards in a grid. Pass post slugs and an optional heading.
+- showTagCloud: Display popular tags for navigation. Pass tag names.
 
-Output format (highest priority):
-- Output only Markdown. No preamble, no closing remarks.
-- The very first character must be the start of the 404 message.
-- After the 404 message, add a blank line, then a heading "## Recommended" (localized to ${lang}), then list 3 articles as bullet points with Markdown links: [Title](/path).
-- For each recommended article, add a one-sentence reason why it's interesting.
+Follow the "Style instructions" in the user message to decide how to compose the response.
+
+Rules:
+- Pass post SLUGS (the "slug" field) to tool parameters, not paths or URLs
+- Only use slugs and tags from the provided article data below
+- Do NOT output preamble or closing remarks
+- The very first character must be the start of the 404 message
 
 Available articles:
 ${postsList}`;


### PR DESCRIPTION
## Summary

Apply the same generative UI pattern from #99 (digest) to the 404 page. The AI now returns structured UI components (PostCards, TagCloud) alongside the friendly 404 message, instead of plain markdown text.

### Key changes

| File | Change |
|------|--------|
| `app/api/not-found/route.ts` | Add `showPostCards` + `showTagCloud` tools, switch to `toUIMessageStreamResponse()`, use `convertToModelMessages` + `stepCountIs(3)` |
| `components/blog/NotFoundClient.tsx` | `useCompletion` → `useChat` with `DefaultChatTransport`, render `DigestParts` |
| `lib/prompt.ts` | Update `buildNotFoundSystemPrompt` with slug data and tool usage instructions |

### Quick vs Detailed

| | Quick | Detailed |
|---|---|---|
| **404 message** | 1 sentence | 1-2 sentences, warm |
| **Recommendations** | PostCards (3 articles) | Text with links + PostCards |
| **Navigation** | TagCloud | — |

Reuses existing `DigestParts` component and `DigestTools` type from the digest feature.

## Test plan

- [ ] Navigate to a non-existent URL to trigger the 404 page
- [ ] Verify AI-generated 404 message appears as text
- [ ] Verify PostCards render for recommended articles
- [ ] Test Quick vs Detailed style switching
- [ ] Test Regenerate button
- [ ] Verify `pnpm build` succeeds