### PR TITLE
Configure Renovate automerge and release age rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,16 +3,36 @@
   extends: ["config:best-practices", "group:definitelyTyped"],
   packageRules: [
     {
-      description: "Group minor and patch updates for production dependencies",
+      description:
+        "Automerge minor and patch updates for production npm dependencies after a 7 day minimum release age",
       groupName: "dependencies (non-major)",
+      matchManagers: ["npm"],
       matchDepTypes: ["dependencies"],
       matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
     },
     {
-      description: "Group minor and patch updates for dev dependencies",
+      description:
+        "Automerge minor and patch updates for development npm dependencies after a 7 day minimum release age",
       groupName: "devDependencies (non-major)",
+      matchManagers: ["npm"],
       matchDepTypes: ["devDependencies"],
       matchUpdateTypes: ["minor", "patch"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
+    },
+    {
+      description:
+        "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
+      groupName: "github-actions (non-major)",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest", "pinDigest"],
+      automerge: true,
+      automergeType: "pr",
+      minimumReleaseAge: "7 days",
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,8 +3,7 @@
   extends: ["config:best-practices", "group:definitelyTyped"],
   packageRules: [
     {
-      description:
-        "Automerge minor and patch updates for production npm dependencies after a 7 day minimum release age",
+      description: "Automerge minor and patch updates for production npm dependencies after a 7 day minimum release age",
       groupName: "dependencies (non-major)",
       matchManagers: ["npm"],
       matchDepTypes: ["dependencies"],
@@ -14,8 +13,7 @@
       minimumReleaseAge: "7 days",
     },
     {
-      description:
-        "Automerge minor and patch updates for development npm dependencies after a 7 day minimum release age",
+      description: "Automerge minor and patch updates for development npm dependencies after a 7 day minimum release age",
       groupName: "devDependencies (non-major)",
       matchManagers: ["npm"],
       matchDepTypes: ["devDependencies"],
@@ -25,8 +23,7 @@
       minimumReleaseAge: "7 days",
     },
     {
-      description:
-        "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
+      description: "Automerge minor, patch, digest, and pinDigest GitHub Actions updates after a 7 day minimum release age",
       groupName: "github-actions (non-major)",
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["minor", "patch", "digest", "pinDigest"],


### PR DESCRIPTION
Summary

Update Renovate to automerge non-major npm and GitHub Actions updates after a 7 day minimum release age.

Changes

- add automerge, PR automerge type, and a 7 day minimum release age to non-major npm dependency updates
- add automerge, PR automerge type, and a 7 day minimum release age to non-major npm devDependency updates
- add a GitHub Actions rule for minor, patch, digest, and pinDigest updates with the same automerge and release age policy
- keep the existing schema and base presets of `config:best-practices` and `group:definitelyTyped`

Why

This repo already groups non-major npm updates, but it does not delay automerge long enough to avoid very fresh regressions and it does not apply the same policy to GitHub Actions updates.

Notes

- `renovate.json5` already existed, so no config file rename was needed.
- `npx -y renovate-config-validator` returned an npm 404 in this environment, so validation used `npx -y --package renovate renovate-config-validator renovate.json5` instead.

Testing

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build:content-index`
- `pnpm build`
- `npx -y --package renovate renovate-config-validator renovate.json5`
- `node` evaluation of `renovate.json5` to confirm the schema, base presets, package rules, automerge settings, and `minimumReleaseAge` values
